### PR TITLE
Revert to Ubuntu 20.04 for AppImage compatibility

### DIFF
--- a/linux-appimage/Dockerfile
+++ b/linux-appimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:20.04
 LABEL maintainer="citraemu"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,6 +9,13 @@ RUN useradd -m -u 1027 -s /bin/bash citra
 # Update system, install PPAs and install packages for building Citra.
 RUN apt-get update && apt-get full-upgrade -y
 RUN apt-get install -y software-properties-common lsb-release
+RUN add-apt-repository -y ppa:savoury1/build-tools
+RUN add-apt-repository -y ppa:savoury1/display
+RUN add-apt-repository -y ppa:savoury1/ffmpeg4
+RUN add-apt-repository -y ppa:savoury1/gcc-defaults-11
+RUN add-apt-repository -y ppa:savoury1/llvm-defaults-13
+RUN add-apt-repository -y ppa:savoury1/qt-6-2
+RUN add-apt-repository -y ppa:theofficialgman/gpu-tools
 RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y
 RUN apt-get install -y \
     build-essential \
@@ -17,9 +24,6 @@ RUN apt-get install -y \
     gcc-11 \
     g++-11 \
     cpp-11 \
-    llvm \
-    clang \
-    clang-format-15 \
 # Qt 6
     qt6-base-dev \
     qt6-base-private-dev \
@@ -51,6 +55,13 @@ RUN apt-get install -y \
     file \
 # qt6gtk2 dependencies
     gtk2.0
+    
+# Install LLVM 15
+RUN wget https://apt.llvm.org/llvm.sh
+RUN chmod +x llvm.sh
+RUN ./llvm.sh 15 all
+RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 150
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 150
 
 # Compile and install qt6gtk2
 RUN git clone --recursive https://github.com/trialuser02/qt6gtk2


### PR DESCRIPTION
Hey there!

I noticed that the current CI setup is using a Docker image based on Ubuntu `24.10`, which is causing some compatibility issues with a few Linux distros that use `glibc` versions older than `2.38` (like SteamOS `3.5.19`, Ubuntu `20.04 LTS`, and Debian `12`).

When running the *AppImage*, users are seeing this error (same as reported PabloMK7/citra#252):

```bash
./citra-qt.AppImage
/tmp/.mount_citra-n0AVVL/AppRun.wrapped: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /tmp/.mount_citra-n0AVVL/AppRun.wrapped)
...
```

To fix this, I’m proposing we switch back to using Ubuntu `20.04`, which is still supported until April 2025. This should help ensure everything runs smoothly on all major LTS and stable Linux distributions.

Also, just a reminder from the `linuxdeployqt` docs: it’s generally a good idea to target the oldest supported Ubuntu LTS version for compatibility, and `20.04` fits the bill perfectly!

**I’ve tested the changes, and it looks like the AppImages are now working fine without hitting the `GLIBC_2.38` error.**

Let me know what you think, and if there’s anything else you’d like me to change!

Thanks!